### PR TITLE
Make different data possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,3 @@ middleware:
     onStartup: true
 ```
 
-
-
-

--- a/README.md
+++ b/README.md
@@ -2,25 +2,27 @@
 
 Instructions:
 
-1) git clone git@github.com:vivo-community/scholars-discovery.git 
-2) git clone git@github.com:vivo-project/sample-data.git
+1) git clone https://github.com/vivo-community/scholars-discovery.git 
+2) git clone https://github.com/vivo-project/sample-data.git
 
 NOTE: everything assumes the scholars-discovery code is checked out into the 
 `scholars-discovery` directory, and `sample-data` into a
 `sample-data` directory
 
-If you have already imported data (see below) can just run:
+** NOTE: skip to next #3 if doing this first time **
+
+**If you have already imported data (see below) can just run:**
 
 3) `docker-compose up`
 
-else (import some data)
+**else** (import some data)
 
 3) `cd data-importer`
 4) `./gradlew build` (or `gradlew.bat` on Windows)
 5) `./gradlew run --args='openvivo --import'`
 
 That should (after 5-10 minutes) put data in the data-imported/openvivo
-directory.  Then 
+directory.  Then `cd ..` (back up to scholars-discovery-setup directory)
 
 6) `docker-compose up`
 

--- a/application-dev.yml
+++ b/application-dev.yml
@@ -5,7 +5,7 @@ middleware:
 vivo:
   triplestore:
     type: TDB
-    directory: /data
+    directory: /data/openvivo
 
 spring:
   data:

--- a/data-importer/src/main/kotlin/main.kt
+++ b/data-importer/src/main/kotlin/main.kt
@@ -13,7 +13,6 @@ import org.apache.jena.query.ReadWrite
 import org.apache.jena.query.ResultSet
 import org.apache.jena.util.FileManager
 
-import org.apache.jena.rdf.model.Model
 import org.apache.jena.riot.RDFDataMgr
 
 import org.apache.logging.log4j.LogManager
@@ -39,7 +38,6 @@ class TDBConnector(val base: String) : Closeable {
     fun importDukeData() {
         logger.debug("importing duke data")
         ds.begin(ReadWrite.WRITE)
-        //val model: Model = ds.getDefaultModel()
         val model = ds.getNamedModel("duke")
         RDFDataMgr.read(model, "../content.trig")
         model.close()
@@ -50,7 +48,6 @@ class TDBConnector(val base: String) : Closeable {
     fun importFloridaData() {
         logger.debug("importing florida data")
         ds.begin(ReadWrite.WRITE)
-        //val model: Model = ds.getDefaultModel()
         val model = ds.getNamedModel("florida")
         val fileManager = FileManager()
         fileManager.addLocatorZip("../sample-data/uf/uf01.ttl.zip")
@@ -60,7 +57,7 @@ class TDBConnector(val base: String) : Closeable {
         fileManager.readModel(model, "uf01.ttl")
         fileManager.readModel(model, "uf02.ttl")
         fileManager.readModel(model, "uf03.ttl")
-         
+
         model.close()
         ds.commit()
         ds.end()
@@ -71,7 +68,7 @@ class TDBConnector(val base: String) : Closeable {
         ds.begin(ReadWrite.WRITE)
         // NOTE: I tried ds.getDefaultModel() it never seemed to work
         val model = ds.getNamedModel("openvivo")
-        val fileManager: FileManager = FileManager()
+        val fileManager = FileManager()
         fileManager.addLocatorZip("../sample-data/openvivo/openvivo.ttl.zip")
         fileManager.readModel(model, "openvivo.ttl")
         model.close()
@@ -96,29 +93,6 @@ fun importData(dataset: String) {
         }
     }
 }
-
-/*
-fun importOpenVivoData() {
-    val connector = TDBConnector("openvivo")
-    connector.use { c ->
-        c.importOpenVivoData()
-    }
-}
-
-fun importDukeData() {
-    val connector = TDBConnector("duke")
-    connector.use { c ->
-        c.importDukeData()
-    }
-}
-
-fun importFloridaData() {
-    val connector = TDBConnector("florida")
-    connector.use { c ->
-        c.importFloridaData()
-    }
-}
-*/
 
 // http://xmlns.com/foaf/0.1/Person
 fun listPeople(dataset: String) {
@@ -151,7 +125,7 @@ fun main(args: Array<String>) {
         println("usage ./gradlew run --args='(openvivo|florida|duke) --import'")
     } else if (args.size == 1) {
         listPeople(args[0])
-    } else if (args.size == 2 && args[1] == "--import"){
+    } else if (args.size == 2 && args[1] == "--import") {
         importData(args[0])
     }
 }

--- a/data-importer/src/main/resources/log4j2.xml
+++ b/data-importer/src/main/resources/log4j2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss} [%t] %-5p %c{1}:%L - %msg%n" />
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console" />
+        </Root>
+    </Loggers>
+</Configuration>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
      #- ./scholars-discovery/pom.xml:/app/pom.xml
      - maven_data:/root/.m2
      - ./application-dev.yml:/app/application-dev.yml
-     - ./data-imported/openvivo:/data
+     - ./data-imported:/data
      - ./scholars-discovery:/app
     #command: ["mvn", "spring-boot:run", "-Dspring-boot.run.profiles=dev", "-Dspring-boot.run.config.location=/app/"]
     command: >

--- a/reload.sh
+++ b/reload.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+docker-compose down middleware
+docker-compose up middleware


### PR DESCRIPTION
I think this lets you point the application-dev.yml to a different directory - while still using the data-importer to create a tdb diretory (for now that's just florida data from "sample-data" project).

The problem is right now the florida data takes at least hours to index, and also have an overview that is bigger than the biggest string allowable.  So ... it's just a theoretical thing.  And this is just a temporary project anyway.  So, no big deal